### PR TITLE
Add PMCC website

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,19 @@
 # Installation 
 
 See:  
-🚀 [Self-hosting](https://twenty.com/developers/section/self-hosting)  
-🖥️ [Local Setup](https://twenty.com/developers/local-setup)  
+🚀 [Self-hosting](https://twenty.com/developers/section/self-hosting)
+🖥️ [Local Setup](https://twenty.com/developers/local-setup)
+
+## Quick Start
+
+```bash
+git clone …
+cd …
+npm install
+npm run dev
+```
+
+Real content/images should replace placeholders.
 
 # Does the world need another CRM?
 

--- a/pmcc-site/index.html
+++ b/pmcc-site/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PMCC</title>
+    <meta property="og:title" content="PMCC" />
+    <link rel="icon" type="image/svg+xml" href="/assets/pmcc-logo.svg" />
+  </head>
+  <body class="bg-pmccGray">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/pmcc-site/package.json
+++ b/pmcc-site/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "pmcc-website",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.2",
+    "react-hook-form": "^7.49.2",
+    "classnames": "^2.3.2"
+  },
+  "devDependencies": {
+    "vite": "^4.4.9",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.32",
+    "autoprefixer": "^10.4.17"
+  }
+}

--- a/pmcc-site/postcss.config.js
+++ b/pmcc-site/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/pmcc-site/public/assets/pmcc-logo.svg
+++ b/pmcc-site/public/assets/pmcc-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#D22129"/>
+  <text x="50" y="55" font-size="45" text-anchor="middle" fill="white" font-family="Arial, sans-serif">PMCC</text>
+</svg>

--- a/pmcc-site/src/App.jsx
+++ b/pmcc-site/src/App.jsx
@@ -1,0 +1,26 @@
+import { Routes, Route } from 'react-router-dom';
+import Navbar from './components/Navbar';
+import Footer from './components/Footer';
+import Home from './pages/Home';
+import About from './pages/About';
+import Services from './pages/Services';
+import Projects from './pages/Projects';
+import Contact from './pages/Contact';
+
+export default function App() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <main className="flex-grow">
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/services" element={<Services />} />
+          <Route path="/projects" element={<Projects />} />
+          <Route path="/contact" element={<Contact />} />
+        </Routes>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/pmcc-site/src/components/Footer.jsx
+++ b/pmcc-site/src/components/Footer.jsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="bg-pmccBlack text-white text-center py-4">
+      © {new Date().getFullYear()} PMCC
+    </footer>
+  );
+}

--- a/pmcc-site/src/components/Hero.jsx
+++ b/pmcc-site/src/components/Hero.jsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom';
+import logo from '/assets/pmcc-logo.svg';
+
+export default function Hero() {
+  return (
+    <div className="relative bg-pmccRed text-white flex items-center justify-center h-64">
+      <img src={logo} alt="PMCC" className="absolute inset-0 w-full h-full object-cover opacity-25" />
+      <div className="relative z-10 text-center">
+        <h1 className="text-4xl font-bold mb-4">Building Better Futures</h1>
+        <Link
+          to="/contact"
+          className="bg-pmccBlack text-white px-4 py-2 rounded"
+        >
+          Contact Us
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/pmcc-site/src/components/Navbar.jsx
+++ b/pmcc-site/src/components/Navbar.jsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { Link, NavLink } from 'react-router-dom';
+import classNames from 'classnames';
+import logo from '/assets/pmcc-logo.svg';
+
+const links = [
+  { to: '/', label: 'Home' },
+  { to: '/about', label: 'About' },
+  { to: '/services', label: 'Services' },
+  { to: '/projects', label: 'Projects' },
+  { to: '/contact', label: 'Contact' }
+];
+
+export default function Navbar() {
+  const [open, setOpen] = useState(false);
+  return (
+    <nav className="bg-white shadow">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between h-16 items-center">
+          <Link to="/" className="flex items-center" onClick={() => setOpen(false)}>
+            <img src={logo} alt="PMCC logo" className="h-6" />
+          </Link>
+          <div className="-mr-2 flex md:hidden">
+            <button
+              onClick={() => setOpen(!open)}
+              className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-pmccRed hover:bg-gray-100 focus:outline-none"
+            >
+              <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="2">
+                <path strokeLinecap="round" strokeLinejoin="round" d={open ? 'M6 18L18 6M6 6l12 12' : 'M4 6h16M4 12h16M4 18h16'} />
+              </svg>
+            </button>
+          </div>
+          <div className="hidden md:block">
+            <div className="ml-10 flex items-baseline space-x-4">
+              {links.map(link => (
+                <NavLink
+                  key={link.to}
+                  to={link.to}
+                  className={({ isActive }) =>
+                    classNames(
+                      'px-3 py-2 rounded-md text-sm font-medium',
+                      isActive ? 'text-pmccRed' : 'text-gray-700 hover:text-pmccRed'
+                    )
+                  }
+                >
+                  {link.label}
+                </NavLink>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      {open && (
+        <div className="md:hidden px-2 pt-2 pb-3 space-y-1 bg-white">
+          {links.map(link => (
+            <NavLink
+              key={link.to}
+              to={link.to}
+              onClick={() => setOpen(false)}
+              className={({ isActive }) =>
+                classNames(
+                  'block px-3 py-2 rounded-md text-base font-medium',
+                  isActive ? 'text-pmccRed' : 'text-gray-700 hover:text-pmccRed'
+                )
+              }
+            >
+              {link.label}
+            </NavLink>
+          ))}
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/pmcc-site/src/components/ProjectCard.jsx
+++ b/pmcc-site/src/components/ProjectCard.jsx
@@ -1,0 +1,7 @@
+export default function ProjectCard({ img }) {
+  return (
+    <div className="shadow">
+      <img src={img} alt="project" className="w-full h-40 object-cover" />
+    </div>
+  );
+}

--- a/pmcc-site/src/components/ServiceCard.jsx
+++ b/pmcc-site/src/components/ServiceCard.jsx
@@ -1,0 +1,8 @@
+export default function ServiceCard({ title }) {
+  return (
+    <div className="border-t-4 border-transparent hover:border-pmccRed p-4 shadow">
+      <h3 className="text-lg font-semibold mb-2">{title}</h3>
+      <p className="text-gray-600">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </div>
+  );
+}

--- a/pmcc-site/src/index.css
+++ b/pmcc-site/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/pmcc-site/src/main.jsx
+++ b/pmcc-site/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/pmcc-site/src/pages/About.jsx
+++ b/pmcc-site/src/pages/About.jsx
@@ -1,0 +1,14 @@
+export default function About() {
+  return (
+    <div className="max-w-4xl mx-auto p-4 grid md:grid-cols-2 gap-4">
+      <div>
+        <h2 className="text-2xl font-bold mb-2">Our History</h2>
+        <p className="text-gray-700">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.</p>
+      </div>
+      <div>
+        <h2 className="text-2xl font-bold mb-2">Mission & Values</h2>
+        <p className="text-gray-700">Ut fringilla. Suspendisse potenti. Nunc feugiat mi a tellus consequat imperdiet.</p>
+      </div>
+    </div>
+  );
+}

--- a/pmcc-site/src/pages/Contact.jsx
+++ b/pmcc-site/src/pages/Contact.jsx
@@ -1,0 +1,21 @@
+import { useForm } from 'react-hook-form';
+
+export default function Contact() {
+  const { register, handleSubmit, reset } = useForm();
+  const onSubmit = data => {
+    console.log(data);
+    reset();
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <input {...register('name')} className="w-full border p-2" placeholder="Name" />
+        <input {...register('email')} type="email" className="w-full border p-2" placeholder="Email" />
+        <input {...register('phone')} className="w-full border p-2" placeholder="Phone" />
+        <textarea {...register('message')} className="w-full border p-2" placeholder="Message" />
+        <button type="submit" className="bg-pmccBlack text-white px-4 py-2">Submit</button>
+      </form>
+    </div>
+  );
+}

--- a/pmcc-site/src/pages/Home.jsx
+++ b/pmcc-site/src/pages/Home.jsx
@@ -1,0 +1,9 @@
+import Hero from '../components/Hero';
+
+export default function Home() {
+  return (
+    <div>
+      <Hero />
+    </div>
+  );
+}

--- a/pmcc-site/src/pages/Projects.jsx
+++ b/pmcc-site/src/pages/Projects.jsx
@@ -1,0 +1,13 @@
+import ProjectCard from '../components/ProjectCard';
+
+const images = Array.from({ length: 6 }).map((_, i) => `https://source.unsplash.com/collection/190727/400x300?sig=${i}`);
+
+export default function Projects() {
+  return (
+    <div className="max-w-6xl mx-auto p-4 grid md:grid-cols-3 gap-4">
+      {images.map((img, idx) => (
+        <ProjectCard key={idx} img={img} />
+      ))}
+    </div>
+  );
+}

--- a/pmcc-site/src/pages/Services.jsx
+++ b/pmcc-site/src/pages/Services.jsx
@@ -1,0 +1,18 @@
+import ServiceCard from '../components/ServiceCard';
+
+const services = [
+  'General Contracting',
+  'Design-Build',
+  'Project Management',
+  'Renovation'
+];
+
+export default function Services() {
+  return (
+    <div className="max-w-6xl mx-auto p-4 grid md:grid-cols-4 gap-4">
+      {services.map(s => (
+        <ServiceCard key={s} title={s} />
+      ))}
+    </div>
+  );
+}

--- a/pmcc-site/tailwind.config.js
+++ b/pmcc-site/tailwind.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        pmccRed: '#D22129',
+        pmccBlack: '#000000',
+        pmccGray: '#F7F9FC'
+      }
+    }
+  },
+  plugins: []
+};

--- a/pmcc-site/vite.config.js
+++ b/pmcc-site/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- create `pmcc-site` React+Vite app with Tailwind
- add navbar, footer, hero, services, projects, and contact pages
- brand assets and colors for PMCC
- add quick start snippet in `README.md`

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6873c3937144832f9f2b9545ece90d05